### PR TITLE
Handle spaces before comments

### DIFF
--- a/baron/formatting_grouper.py
+++ b/baron/formatting_grouper.py
@@ -120,12 +120,12 @@ def group_generator(sequence):
         if current is None:
             return
 
-        if current[0] in ("SPACE", "COMMENT") and iterator.show_next() and iterator.show_next()[0] in GROUP_SPACE_BEFORE:
+        if current[0] in ("SPACE") and iterator.show_next() and iterator.show_next()[0] in GROUP_SPACE_BEFORE:
             new_current = next(iterator)
             current = (new_current[0], new_current[1], [current])
 
         if current[0] in GROUP_SPACE_AFTER + STRING and\
-            (iterator.show_next() and iterator.show_next()[0] in ("SPACE", "COMMENT")) and\
+            (iterator.show_next() and iterator.show_next()[0] in ("SPACE")) and\
             (not iterator.show_next(2) or (iterator.show_next(2) and not less_prioritary_than(current[0], iterator.show_next(2)[0]))):
 
             # do not be greedy when you are grouping on strings

--- a/baron/formatting_grouper.py
+++ b/baron/formatting_grouper.py
@@ -110,11 +110,7 @@ def group(sequence):
 
 def group_generator(sequence):
     iterator = FlexibleIterator(sequence)
-    current = None, None
-    while True:
-        if iterator.end():
-            return
-
+    while not iterator.end():
         current = next(iterator)
 
         if current is None:

--- a/tests/test_formatting_grouper.py
+++ b/tests/test_formatting_grouper.py
@@ -2923,3 +2923,39 @@ def test_inconsistancy_on_space_grouping():
         ('STRING', '"a"'),
         ('RIGHT_PARENTHESIS', ')', [('SPACE', ' ')]),
     ])
+
+
+def test_space_before_comment():
+    group([
+        ('ENDL', '\n'),
+        ('SPACE', ' '),
+        ('COMMENT', '# hello'),
+        ('ENDL', '\n'),
+        ('IMPORT', 'import'),
+        ('SPACE', ' '),
+        ('NAME', 're'),
+        ('ENDL', '\n'),
+        ('COMMENT', '# hi'),
+        ('ENDL', '\n'),
+        ('IMPORT', 'import'),
+        ('SPACE', ' '),
+        ('NAME', 'sys'),
+        ('ENDL', '\n'),
+        ('ENDMARKER', ''),
+    ], [
+        ('ENDL', '\n', [], [('SPACE', ' ')]),
+        ('COMMENT', '# hello'),
+        ('ENDL', '\n'),
+        ('IMPORT', 'import', [], [('SPACE', ' ')]),
+        ('NAME', 're'),
+        ('ENDL', '\n'),
+        ('COMMENT', '# hi'),
+        ('ENDL', '\n'),
+        ('IMPORT', 'import', [], [('SPACE', ' ')]),
+        ('NAME', 'sys'),
+        ('ENDL', '\n'),
+        ('ENDMARKER', '')
+    ]
+
+    )
+


### PR DESCRIPTION
This allows comments at the start of the file and comments that are preceded by a space to be detected
and processed with the comment

https://github.com/PyCQA/baron/issues/44

As far as I can see this fix is simple. But as I am new to this code I may have screwed something up so please check it. 