### PR TITLE
Fix markdown syntax for link to code of conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ You can reach us on [irc.freenode.net#baron](https://webchat.freenode.net/?chann
 Code of Conduct
 ===============
 
-As a member of [PyCQA](https://github.com/PyCQA), Baron follows its [Code of Conduct][http://meta.pycqa.org/en/latest/code-of-conduct.html].
+As a member of [PyCQA](https://github.com/PyCQA), Baron follows its [Code of Conduct](http://meta.pycqa.org/en/latest/code-of-conduct.html).
 
 Misc
 ====


### PR DESCRIPTION
The link to the code of conduct in the README wasn't rendering properly because of a markdown syntax error (it showed as the URL and text separately). This fixes that.