### PR TITLE
Updated the indentation marker to not fail on len 3 lexer tokens.

### DIFF
--- a/baron/indentation_marker.py
+++ b/baron/indentation_marker.py
@@ -35,7 +35,7 @@ def get_space(node):
     a ('ENDL', '\n') node - then we return None as a flag value. This is
     maybe not the best behavior but it seems to work for now.
     """
-    if len(node) < 3 or len(node[3]) == 0:
+    if len(node) < 4 or len(node[3]) == 0:
         return None
     return transform_tabs_to_spaces(node[3][0][1])
 

--- a/tests/test_indentation_marker.py
+++ b/tests/test_indentation_marker.py
@@ -46,6 +46,35 @@ def test_dumy_if():
     ])
 
 
+def test_dumy_def_space():
+    """
+    def foo():
+        pass     
+    """
+    # https://github.com/PyCQA/baron/issues/101
+    check([
+        ('DEF', 'def', [], [('SPACE', ' ')]),
+        ('NAME', 'foo'),
+        ('LEFT_PARENTHESIS', '('),
+        ('RIGHT_PARENTHESIS', ')'),
+        ('COLON', ':'),
+        ('ENDL', '\n', [], [('SPACE', '    ')]),
+        ('PASS', 'pass'),
+        ('ENDL', '\n', [('SPACE', '   ')]),
+    ],  [
+        ('DEF', 'def', [], [('SPACE', ' ')]),
+        ('NAME', 'foo'),
+        ('LEFT_PARENTHESIS', '('),
+        ('RIGHT_PARENTHESIS', ')'),
+        ('COLON', ':'),
+        ('ENDL', '\n', [], [('SPACE', '    ')]),
+        ('INDENT', ''),
+        ('PASS', 'pass'),
+        ('ENDL', '\n', [('SPACE', '   ')]),
+        ('DEDENT', ''),
+    ])
+
+
 def test_dumy_if_if():
     """
     if a:


### PR DESCRIPTION
Adding "test_dumy_def_space" to "test_indentation.py" testing for #101 

From what I can tell this is an acceptable resolution to #101.
The issue occurs when empty spaces are added at the end of a line just before a DEDENT.
The lexer produces a 3 length token structure of the following: <class 'tuple'>: ('ENDL', '\n', [('SPACE', '   ')])


This gets created at:
https://github.com/PyCQA/baron/blob/master/baron/formatting_grouper.py#L124-L126

And does not get caught by 
https://github.com/PyCQA/baron/blob/master/baron/formatting_grouper.py#L128-L130
or
https://github.com/PyCQA/baron/blob/master/baron/formatting_grouper.py#L142

Because the next token after the ENDL is not a space.