### PR TITLE
add support for typed function parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.swo
 __pycache__
 .coverage
+.pytest_cache/
+baron.egg-info/

--- a/baron/grammator_primitives.py
+++ b/baron/grammator_primitives.py
@@ -260,6 +260,12 @@ def include_primivites(pg, print_function):
         return [create_node_from_token(name)]
 
 
+    @pg.production("names : NAME")
+    def names_name(pack):
+        (name,) = pack
+        return [create_node_from_token(name)]
+
+
     @pg.production("names : names comma name")
     def names_names_name(pack):
         (names, comma, name,) = pack

--- a/baron/render.py
+++ b/baron/render.py
@@ -730,6 +730,13 @@ nodes_rendering_order = {
             ("formatting", "second_formatting", "target"),
             ("string",     "target",            "target"),
         ],
+        "typed_name": [
+            ("string",     "value",             True),
+            ("formatting", "first_formatting",  True),
+            ("constant",   ":",                 True),
+            ("formatting", "second_formatting", True),
+            ("key",        "annotation",        True),
+        ],
 
         "print": [
             ("constant",   "print",                  True),

--- a/grammar/baron_grammar
+++ b/grammar/baron_grammar
@@ -17,12 +17,16 @@ decorator: '@' dotted_name [ '(' [arglist] ')' ] NEWLINE
 decorators: decorator+
 decorated: decorators (classdef | funcdef)
 funcdef: 'def' NAME parameters ':' suite
-parameters: '(' [varargslist] ')'
+parameters: '(' [typedargslist] ')'
+typedargslist: ((tfpdef ['=' test] ',')*
+                ('*' NAME [',' '**' NAME] | '**' NAME) |
+                tfpdef ['=' test] (',' tfpdef ['=' test])* [','])
 varargslist: ((fpdef ['=' test] ',')*
               ('*' NAME [',' '**' NAME] | '**' NAME) |
               fpdef ['=' test] (',' fpdef ['=' test])* [','])
 fpdef: NAME | '(' fplist ')'
 fplist: fpdef (',' fpdef)* [',']
+tfpdef: NAME [':' test] | '(' fplist ')'
 
 stmt: simple_stmt | compound_stmt
 simple_stmt: small_stmt (';' small_stmt)* [';'] NEWLINE

--- a/tests/test_grammator.py
+++ b/tests/test_grammator.py
@@ -581,6 +581,73 @@ def test_funcdef_stmt_one_parameter_indent():
         }
     ])
 
+def test_funcdef_stmt_one_parameter_typed_indent():
+    """
+    def a ( x : int ) :
+        pass
+    """
+    parse_multi([
+        ('DEF', 'def', [], [('SPACE', ' ')]),
+        ('NAME', 'a'),
+        ('LEFT_PARENTHESIS', '(', [('SPACE', ' ')], [('SPACE', ' ')]),
+        ('NAME', 'x'),
+        ('COLON', ':', [('SPACE', ' ')], [('SPACE', ' ')]),
+        ('NAME', 'int'),
+        ('RIGHT_PARENTHESIS', ')', [('SPACE', ' ')]),
+        ('COLON', ':', [('SPACE', ' ')]),
+        ('ENDL', '\n', [], [('SPACE', '    ')]),
+        ('INDENT', ''),
+        ('PASS', 'pass'),
+        ('ENDL', '\n'),
+        ('DEDENT', ''),
+    ], [
+        {
+            "type": "def",
+            "name": "a",
+            "decorators": [],
+            "async": False,
+            "async_formatting": [],
+            "first_formatting": [{"type": "space", "value": " "}],
+            "second_formatting": [{"type": "space", "value": " "}],
+            "third_formatting": [{"type": "space", "value": " "}],
+            "fourth_formatting": [{"type": "space", "value": " "}],
+            "fifth_formatting": [{"type": "space", "value": " "}],
+            "sixth_formatting": [],
+            "arguments": [
+                {
+                    "type": "def_argument",
+                    "first_formatting": [],
+                    "second_formatting": [],
+                    "target": {
+                        "type": "typed_name",
+                        "annotation": {"type": "name", "value": "int"},
+                        "first_formatting": [{"type": "space", "value": " "}],
+                        "second_formatting": [{"type": "space", "value": " "}],
+                        "value": "x",
+                    },
+                    "value": {},
+                }
+            ],
+            "value": [
+                {
+                    "type": "endl",
+                    "value": "\n",
+                    "formatting": [],
+                    "indent": "    "
+                },
+                {
+                    "type": "pass",
+                },
+                {
+                    "type": "endl",
+                    "formatting": [],
+                    "indent": "",
+                    "value": "\n"
+                }
+            ],
+        }
+    ])
+
 def test_funcdef_stmt_one_parameter_comma_indent():
     """
     def a ( x , ) :
@@ -717,6 +784,117 @@ def test_funcdef_stmt_one_parameter_comma_default_indent():
                     "formatting": [],
                     "indent": "",
                     "type": "endl",
+                    "value": "\n"
+                }
+            ],
+        }
+    ])
+
+def test_funcdef_stmt_two_parameters_typed_with_default_indent():
+    """
+    def a ( x : int = 1 , y : List[str] ) :
+        pass
+    """
+    parse_multi([
+        ('DEF', 'def', [], [('SPACE', ' ')]),
+        ('NAME', 'a'),
+        ('LEFT_PARENTHESIS', '(', [('SPACE', ' ')], [('SPACE', ' ')]),
+        ('NAME', 'x'),
+        ('COLON', ':', [('SPACE', ' ')], [('SPACE', ' ')]),
+        ('NAME', 'int'),
+        ('EQUAL', '=', [('SPACE', ' ')], [('SPACE', ' ')]),
+        ('INT', '1'),
+        ('COMMA', ',', [('SPACE', ' ')], [('SPACE', ' ')]),
+        ('NAME', 'y'),
+        ('COLON', ':', [('SPACE', ' ')], [('SPACE', ' ')]),
+        ('NAME', 'List'),
+        ('LEFT_SQUARE_BRACKET', '[', [], []),
+        ('NAME', 'str'),
+        ('RIGHT_SQUARE_BRACKET', '[', [], []),
+        ('RIGHT_PARENTHESIS', ')', [('SPACE', ' ')]),
+        ('COLON', ':', [('SPACE', ' ')]),
+        ('ENDL', '\n', [], [('SPACE', '    ')]),
+        ('INDENT', ''),
+        ('PASS', 'pass'),
+        ('ENDL', '\n'),
+        ('DEDENT', ''),
+    ], [
+        {
+            "type": "def",
+            "name": "a",
+            "decorators": [],
+            "async": False,
+            "async_formatting": [],
+            "first_formatting": [{"type": "space", "value": " "}],
+            "second_formatting": [{"type": "space", "value": " "}],
+            "third_formatting": [{"type": "space", "value": " "}],
+            "fourth_formatting": [{"type": "space", "value": " "}],
+            "fifth_formatting": [{"type": "space", "value": " "}],
+            "sixth_formatting": [],
+            "arguments": [
+                {
+                    "type": "def_argument",
+                    "first_formatting": [{"type": "space", "value": " "}],
+                    "second_formatting": [{"type": "space", "value": " "}],
+                    "target": {
+                        "type": "typed_name",
+                        "annotation": {"type": "name", "value": "int"},
+                        "first_formatting": [{"type": "space", "value": " "}],
+                        "second_formatting": [{"type": "space", "value": " "}],
+                        "value": "x",
+                    },
+                    "value": {"section": "number", "type": "int", "value": "1"},
+                },
+                {
+                    "type": "comma",
+                    "first_formatting": [{"type": "space", "value": " "}],
+                    "second_formatting": [{"type": "space", "value": " "}],
+                },
+                {
+                    "type": "def_argument",
+                    "first_formatting": [],
+                    "second_formatting": [],
+                    "target": {
+                        "type": "typed_name",
+                        "annotation":
+                            {
+                                "type": "atomtrailers",
+                                "value": [
+                                    {
+                                        "type": "name",
+                                        "value": "List",
+                                    },
+                                    {
+                                        "type": "getitem",
+                                        "first_formatting": [],
+                                        "second_formatting": [],
+                                        "third_formatting": [],
+                                        "fourth_formatting": [],
+                                        "value": {"type": "name", "value": "str"},
+                                    }
+                                ]
+                            },
+                        "first_formatting": [{"type": "space", "value": " "}],
+                        "second_formatting": [{"type": "space", "value": " "}],
+                        "value": "y",
+                    },
+                    "value": {},
+                },
+            ],
+            "value": [
+                {
+                    "type": "endl",
+                    "value": "\n",
+                    "formatting": [],
+                    "indent": "    "
+                },
+                {
+                    "type": "pass",
+                },
+                {
+                    "type": "endl",
+                    "formatting": [],
+                    "indent": "",
                     "value": "\n"
                 }
             ],


### PR DESCRIPTION
Resolves https://github.com/PyCQA/baron/issues/127

Please let me know what you think.

This should allow for typed parameters like `def foo(x: int)` and `def foo(x: List[int])`. I didn't try testing when parameters like `*args` or `**kwargs` are typed. I think that would be good to add in the future but it just wasn't as necessary for me at the moment.

This does not add support for typed variables or function return types, but I hope to add support for the later in the near future assuming this is accepted.