### PR TITLE
add support for variable annotations

### DIFF
--- a/baron/grammator_operators.py
+++ b/baron/grammator_operators.py
@@ -18,6 +18,25 @@ def include_operators(pg):
         (old_test, comma, testlist_safe) = pack
         return [old_test, comma] + testlist_safe
 
+    @pg.production("annassign : COLON test maybe_test")
+    def annassign(pack):
+        return pack
+
+    @pg.production("expr_stmt : test annassign")
+    def augmented_assignment_node(pack):
+        (target, (colon, annotation, (equal, test))) = pack
+        return {
+            "type": "annassign",
+            "first_formatting": colon.hidden_tokens_before,
+            "second_formatting": colon.hidden_tokens_after,
+            "third_formatting": equal.hidden_tokens_before if equal else [],
+            "fourth_formatting": equal.hidden_tokens_after if equal else [],
+            "target": target,
+            "value": test,
+            "annotation": annotation,
+            "has_value": equal is not None
+        }
+
     @pg.production("expr_stmt : testlist augassign_operator testlist")
     @pg.production("expr_stmt : testlist augassign_operator yield_expr")
     def augmented_assignment_node(pack):

--- a/baron/render.py
+++ b/baron/render.py
@@ -480,6 +480,19 @@ nodes_rendering_order = {
             ("key",        "value",             True),
         ],
 
+        "annassign": [
+            ("key",        "target",            True),
+            ("formatting", "first_formatting",  True),
+            ("constant",   ":",                 True),
+            ("formatting", "second_formatting", True),
+            ("key",        "annotation",        True),
+            ("formatting", "third_formatting",  "has_value"),
+            ("constant",   "=",                 "has_value"),
+            ("formatting", "fourth_formatting", "has_value"),
+            ("key",        "value",             "has_value"),
+            ("bool",       "has_value",         False),
+        ],
+
         "unitary_operator": [
             ("string",     "value",             True),
             ("formatting", "formatting",        True),

--- a/grammar/baron_grammar
+++ b/grammar/baron_grammar
@@ -32,8 +32,9 @@ stmt: simple_stmt | compound_stmt
 simple_stmt: small_stmt (';' small_stmt)* [';'] NEWLINE
 small_stmt: (expr_stmt | print_stmt  | del_stmt | pass_stmt | flow_stmt |
              import_stmt | global_stmt | nonlocal_stmt | exec_stmt | assert_stmt)
-expr_stmt: testlist (augassign (yield_expr|testlist) |
+expr_stmt: testlist (annassign | augassign (yield_expr|testlist) |
                      ('=' (yield_expr|testlist))*)
+annassign: ':' test ['=' test]
 augassign: ('+=' | '-=' | '*=' | '@=' | '/=' | '%=' | '&=' | '|=' | '^=' |
             '<<=' | '>>=' | '**=' | '//=')
 # For normal assignments, additional restrictions enforced by the interpreter

--- a/tests/test_grammator.py
+++ b/tests/test_grammator.py
@@ -2720,3 +2720,51 @@ def test_regression_def_argument_tuple_nested():
             ]
         }
     ])
+
+
+def test_typed_variable_no_assignment():
+    """
+    x : int
+    """
+    parse_simple([
+        ('NAME', 'x'),
+        ('COLON', ':', [('SPACE', ' ')], [('SPACE', ' ')]),
+        ('NAME', 'int'),
+    ], [
+        {
+            "type": "annassign",
+            "annotation": {"type": "name", "value": "int"},
+            "first_formatting": [{"type": "space", "value": " "}],
+            "second_formatting": [{"type": "space", "value": " "}],
+            "third_formatting": [],
+            "fourth_formatting": [],
+            "target": {"type": "name", "value": "x"},
+            "has_value": False,
+            "value": {}
+        }
+    ])
+
+
+def test_typed_variable_with_assignment():
+    """
+    x : int = 1
+    """
+    parse_simple([
+        ('NAME', 'x'),
+        ('COLON', ':', [('SPACE', ' ')], [('SPACE', ' ')]),
+        ('NAME', 'int'),
+        ('EQUAL', '=', [('SPACE', ' ')], [('SPACE', ' ')]),
+        ('INT', '1'),
+    ], [
+        {
+            "type": "annassign",
+            "annotation": {"type": "name", "value": "int"},
+            "first_formatting": [{"type": "space", "value": " "}],
+            "second_formatting": [{"type": "space", "value": " "}],
+            "third_formatting": [{"type": "space", "value": " "}],
+            "fourth_formatting": [{"type": "space", "value": " "}],
+            "target": {"type": "name", "value": "x"},
+            "has_value": True,
+            "value": {"section": "number", "type": "int", "value": "1"}
+        }
+    ])


### PR DESCRIPTION
This adds support for variable annotations such as `x: int = 1` and `y: str`. There was another PR that was similar (https://github.com/PyCQA/baron/pull/116) but I think this more closely matches the python grammar.

I have a related redbaron PR that I will push shortly.