### PR TITLE
Add missing comma in Python string list

### DIFF
--- a/baron/inner_formatting_grouper.py
+++ b/baron/inner_formatting_grouper.py
@@ -73,7 +73,7 @@ GROUP_ON = (
     "AT",
     "IF",
     "ELSE",
-    "FROM"
+    "FROM",
     "EQUAL",
     "PLUS_EQUAL",
     "MINUS_EQUAL",


### PR DESCRIPTION
In Python, two adjacent strings get concatenated implicitly.
Missing commas in multi-line string lists is a common source of bugs
causing unwanted string concatenation. In this case, it is clear that this
comma is missing by mistake and there should not be a concatenation.