### PR TITLE
Fix dict containing a double star unpacking parameter

### DIFF
--- a/baron/grammator_data_structures.py
+++ b/baron/grammator_data_structures.py
@@ -154,7 +154,7 @@ def include_data_structures(pg):
         return []
 
     @pg.production("dictmaker : test COLON test")
-    def dict_one(pack):
+    def dict_one_colon(pack):
         (test, colon, test2) = pack
         return [{
             "first_formatting": colon.hidden_tokens_before,
@@ -164,8 +164,20 @@ def include_data_structures(pg):
             "type": "dictitem"
         }]
 
+    @pg.production("dictmaker : DOUBLE_STAR test")
+    def dict_one_double_star(pack):
+        (double_star, test) = pack
+        return [{
+            "type": "dict_argument",
+            "annotation": {},
+            "annotation_first_formatting": [],
+            "annotation_second_formatting": [],
+            "formatting": double_star.hidden_tokens_after,
+            "value": test,
+        }]
+
     @pg.production("dictmaker : test COLON test comma dictmaker")
-    def dict_more(pack):
+    def dict_more_colon(pack):
         (test, colon, test2, comma, dictmaker) = pack
         return [{
             "first_formatting": colon.hidden_tokens_before,
@@ -173,6 +185,18 @@ def include_data_structures(pg):
             "key": test,
             "value": test2,
             "type": "dictitem"
+        }, comma] + dictmaker
+
+    @pg.production("dictmaker : DOUBLE_STAR test comma dictmaker")
+    def dict_more_double_star(pack):
+        (double_star, test, comma, dictmaker) = pack
+        return [{
+            "type": "dict_argument",
+            "annotation": {},
+            "annotation_first_formatting": [],
+            "annotation_second_formatting": [],
+            "formatting": double_star.hidden_tokens_after,
+            "value": test,
         }, comma] + dictmaker
 
     @pg.production("atom : LEFT_BRACKET setmaker RIGHT_BRACKET")

--- a/tests/test_grammator_data_structures.py
+++ b/tests/test_grammator_data_structures.py
@@ -238,7 +238,7 @@ def test_dict_empty():
     ])
 
 
-def test_dict_one():
+def test_dict_one_colon():
     "{a: b}"
     parse_simple([
         ('LEFT_BRACKET', '{', [], []),
@@ -272,7 +272,36 @@ def test_dict_one():
     ])
 
 
-def test_dict_more():
+def test_dict_one_double_star():
+    "{**a}"
+    parse_simple([
+        ('LEFT_BRACKET', '{', [], []),
+        ('DOUBLE_STAR', '**'),
+        ('NAME', 'a'),
+        ('RIGHT_BRACKET', '}', [], []),
+    ], [
+        {
+            'type': 'dict',
+            'first_formatting': [],
+            'second_formatting': [],
+            'third_formatting': [],
+            'fourth_formatting': [],
+            'value': [
+                {
+                    'type': 'dict_argument',
+                    'annotation': {},
+                    'annotation_first_formatting': [],
+                    'annotation_second_formatting': [],
+                    'formatting': [],
+                    'value': {'type': 'name', 'value': 'a'}
+                }
+            ]
+        }
+    ]
+)
+
+
+def test_dict_more_colon():
     "{a: b, b: c, c: d}"
     parse_simple([
         ('LEFT_BRACKET', '{', [], []),
@@ -346,6 +375,69 @@ def test_dict_more():
                     }
                 }
             ],
+        }
+    ])
+
+
+def test_dict_more_double_star():
+    "{**a, b: c}"
+    parse_simple([
+        ('LEFT_BRACKET', '{', [], []),
+        ('DOUBLE_STAR', '**'),
+        ('NAME', 'a'),
+        ('COMMA', ',', [], [('SPACE', ' ')]),
+        ('NAME', 'b'),
+        ('COLON', ':', [], [('SPACE', ' ')]),
+        ('NAME', 'c'),
+        ('RIGHT_BRACKET', '}', [], []),
+    ], [
+        {
+            "first_formatting": [],
+            "fourth_formatting": [],
+            "second_formatting": [],
+            "third_formatting": [],
+            "type": "dict",
+            "value": [
+                {
+                    "annotation": {},
+                    "annotation_first_formatting": [],
+                    "annotation_second_formatting": [],
+                    "formatting": [],
+                    "type": "dict_argument",
+                    "value": {
+                        "type": "name",
+                        "value": "a"
+                    }
+                },
+                {
+                    "first_formatting": [],
+                    "second_formatting": [
+                        {
+                            "type": "space",
+                            "value": " "
+                        }
+                    ],
+                    "type": "comma"
+                },
+                {
+                    "first_formatting": [],
+                    "key": {
+                        "type": "name",
+                        "value": "b"
+                    },
+                    "second_formatting": [
+                        {
+                            "type": "space",
+                            "value": " "
+                        }
+                    ],
+                    "type": "dictitem",
+                    "value": {
+                        "type": "name",
+                        "value": "c"
+                    }
+                }
+            ]
         }
     ])
 

--- a/tests/test_indentation_marker.py
+++ b/tests/test_indentation_marker.py
@@ -7,7 +7,7 @@ from .test_utils import zip_longest
 
 
 def check(input_, output):
-    for i, j in zip_longest(mark_indentation(input + [('ENDMARKER', ''), None]),
+    for i, j in zip_longest(mark_indentation(input_ + [('ENDMARKER', ''), None]),
                             output + [('ENDMARKER', ''), None]):
         assert i == j
 
@@ -305,8 +305,8 @@ def test_trailing_spaces():
     """
     if a:
         if b:
-            
-        
+
+
             pass
     """
     check([


### PR DESCRIPTION
After running baron on over 1 million lines of code, I found that baron's only missing ability is to parse dicts containing double star dict unpacks. I've added a fix with two corresponding tests. There were some broken tests regardless of my fix.
I hope you will merge this fix ASAP as this is a big issue for me and probably others.

Thanks!