### PR TITLE
When rendering, skip missing keys

### DIFF
--- a/baron/render.py
+++ b/baron/render.py
@@ -88,7 +88,8 @@ def render_node(node, strict=False):
                 raise e
 
         if key_type in ['key', 'string', 'list', 'formatting']:
-            yield (key_type, node[render_key], render_key)
+            if render_key in node:
+                yield (key_type, node[render_key], render_key)
         elif key_type in ['constant', 'string']:
             yield (key_type, render_key, render_key)
         else:


### PR DESCRIPTION
This is a very quick change to provide for rendering structures that are missing nonimportant keys.

```
>>> baron.dumps([dict(type='print', value=[dict(type='associative_parenthesis', value=dict(type='string', value='"hello, world"'))])])
'print("hello, world")'
```